### PR TITLE
Add node dependencies (couldnt run without them)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build":"babel src --out-dir dest",
-    "start":"node dest/client/index.js"
-    },
+    "build": "babel src --out-dir dest",
+    "start": "node dest/client/index.js"
+  },
   "private": true,
   "author": "ekhaemba",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.17.1",
+    "cors": "^2.8.1",
     "express": "^4.15.2",
     "json-schema-faker": "^0.4.0"
   },


### PR DESCRIPTION
When trying to run the fake api, I ran into issues with `cors` and `body-parser` not being installed .These changes add those modules to the list of dependencies so running `npm install` will install them automatically.